### PR TITLE
ESM Support

### DIFF
--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -1,5 +1,6 @@
 const fs = require("fs-extra");
 const path = require("path");
+const url = require("url");
 const { get } = require("lodash");
 
 const DEFAULT_CONFIG_FILE_NAME = "migrate-mongo-config.js";
@@ -60,6 +61,13 @@ module.exports = {
       return customConfigContent;
     }
     const configPath = getConfigPath();
-    return Promise.resolve(require(configPath)); // eslint-disable-line
+    try {
+      return Promise.resolve(require(configPath)); // eslint-disable-line
+    } catch (e) {
+      if (e.code === 'ERR_REQUIRE_ESM') {
+        return Promise.resolve(import(url.pathToFileURL(configPath)));
+      }
+      throw e;
+    }
   }
 };

--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -65,7 +65,7 @@ module.exports = {
       return Promise.resolve(require(configPath)); // eslint-disable-line
     } catch (e) {
       if (e.code === 'ERR_REQUIRE_ESM') {
-        return Promise.resolve(import(url.pathToFileURL(configPath)));
+        return (await import(url.pathToFileURL(configPath))).default;
       }
       throw e;
     }

--- a/lib/env/config.js
+++ b/lib/env/config.js
@@ -2,6 +2,7 @@ const fs = require("fs-extra");
 const path = require("path");
 const url = require("url");
 const { get } = require("lodash");
+const moduleLoader = require('../utils/module-loader');
 
 const DEFAULT_CONFIG_FILE_NAME = "migrate-mongo-config.js";
 
@@ -62,10 +63,10 @@ module.exports = {
     }
     const configPath = getConfigPath();
     try {
-      return Promise.resolve(require(configPath)); // eslint-disable-line
+      return Promise.resolve(moduleLoader.require(configPath));
     } catch (e) {
       if (e.code === 'ERR_REQUIRE_ESM') {
-        return (await import(url.pathToFileURL(configPath))).default;
+        return (await moduleLoader.import(url.pathToFileURL(configPath))).default;
       }
       throw e;
     }

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -1,5 +1,6 @@
 const fs = require("fs-extra");
 const path = require("path");
+const url = require("url");
 const crypto = require("crypto");
 const config = require("./config");
 
@@ -94,11 +95,19 @@ module.exports = {
 
   async loadMigration(fileName) {
     const migrationsDir = await resolveMigrationsDirPath();
-    return require(path.join(migrationsDir, fileName)); // eslint-disable-line
+    const migrationPath = path.join(migrationsDir, fileName);
+    try {
+      return require(migrationPath); // eslint-disable-line
+    } catch (e) {
+      if (e.code === 'ERR_REQUIRE_ESM') {
+        return import(url.pathToFileURL(migrationPath));
+      }
+      throw e;
+    }
   },
 
   async loadFileHash(fileName) {
-    const migrationsDir = await resolveMigrationsDirPath(); 
+    const migrationsDir = await resolveMigrationsDirPath();
     const filePath = path.join(migrationsDir, fileName)
     const hash = crypto.createHash('sha256');
     const input = await fs.readFile(filePath);

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -3,6 +3,7 @@ const path = require("path");
 const url = require("url");
 const crypto = require("crypto");
 const config = require("./config");
+const moduleLoader = require('../utils/module-loader');
 
 const DEFAULT_MIGRATIONS_DIR_NAME = "migrations";
 const DEFAULT_MIGRATION_EXT = ".js";
@@ -97,10 +98,10 @@ module.exports = {
     const migrationsDir = await resolveMigrationsDirPath();
     const migrationPath = path.join(migrationsDir, fileName);
     try {
-      return require(migrationPath); // eslint-disable-line
+      return moduleLoader.require(migrationPath);
     } catch (e) {
       if (e.code === 'ERR_REQUIRE_ESM') {
-        return import(url.pathToFileURL(migrationPath));
+        return moduleLoader.import(url.pathToFileURL(migrationPath));
       }
       throw e;
     }

--- a/lib/utils/module-loader.js
+++ b/lib/utils/module-loader.js
@@ -1,0 +1,10 @@
+module.exports = {
+  require(requirePath) {
+    return require(requirePath); // eslint-disable-line
+  },
+
+  /* istanbul ignore next */
+  import(importPath) {
+    return import(importPath); // eslint-disable-line
+  },
+};


### PR DESCRIPTION
This addresses #248

Checklist
 npm test passes and has 100% coverage
 README.md is updated
These changes allow migrate-mongo to work in projects with "type": "module" set in their package.json file without disrupting other configurations or requiring additional configuration.

Config files should use export default { instead of module.exports = {
Migrations should look like:

````javascript
export const up = async (db, client)  => { ... }
export const down = async (db, client)  => { ... }
````